### PR TITLE
Python 3 compatibility tweaks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 from setuptools import setup
 import stallion
+import sys
 
 # Stallion requirements
 install_requirements = [
@@ -17,6 +18,15 @@ except ImportError:
     install_requirements.append('simplejson>=2.3.0')
 
 
+def long_description():
+    if sys.version_info >= (3, 0, 0):
+        f = open("README.rst", mode="r", encoding="utf-8")
+    else:
+        f = open("README.rst", mode="r")
+
+    return f.read()
+
+
 setup(
     name='Stallion',
     version=stallion.__version__,
@@ -25,7 +35,7 @@ setup(
     author=stallion.__author__,
     author_email='christian.perone@gmail.com',
     description='A Python Package Manager interface.',
-    long_description=open("README.rst", "r").read(),
+    long_description=long_description(),
     packages=['stallion'],
     keywords='package manager, distribution tool, stallion',
     platforms='Any',

--- a/stallion/main.py
+++ b/stallion/main.py
@@ -13,7 +13,11 @@ from optparse import OptionParser
 import sys
 import platform
 import logging
-import xmlrpclib
+
+try:
+    import xmlrpclib
+except ImportError:
+    import xmlrpc.client
 
 import pkg_resources as _pkg_resources
 
@@ -251,8 +255,8 @@ def distribution(dist_name=None):
 def run_main():
     """ The main entry-point of Stallion. """
 
-    print 'Stallion %s - Python Package Manager' % (stallion.__version__,)
-    print 'By %s 2011\n' % (stallion.__author__,)
+    print('Stallion %s - Python Package Manager' % (stallion.__version__,))
+    print('By %s 2011\n' % (stallion.__author__,))
     parser = OptionParser()
 
     parser.add_option('-s', '--host', dest='host',
@@ -287,7 +291,7 @@ def run_main():
     (options, args) = parser.parse_args()
 
     if not options.verbose:
-        print " * Running on http://%s:%s/" % (options.host, options.port)
+        print(" * Running on http://%s:%s/" % (options.host, options.port))
         werk_log = logging.getLogger('werkzeug')
         werk_log.setLevel(logging.WARNING)
 

--- a/stallion/metadata.py
+++ b/stallion/metadata.py
@@ -76,7 +76,7 @@ def parse_metadata(metadata):
     """
     parsed_metadata = Parser().parsestr(metadata)
     metadata_spec = set(HEADER_META[parsed_metadata['metadata-version']])
-    key_exist = set(map(string.lower, parsed_metadata.keys()))
+    key_exist = set([s.lower() for s in parsed_metadata.keys()])
     return (parsed_metadata, key_exist.intersection(metadata_spec))
 
 
@@ -122,7 +122,7 @@ def field_process(field_name, field_value):
             d = root
             path_split = tuple([s.strip() for s in line.split('::')])
             for level in path_split:
-                if d.has_key(level):
+                if level in d:
                     d = d[level]
                 else:
                     b = {}
@@ -135,7 +135,9 @@ def field_process(field_name, field_value):
         return field_value
 
     f_value = clean_lead_ws_description(field_value, field_name)
-    f_value = f_value.decode('utf-8')
+
+    if hasattr(f_value, 'decode'):
+        f_value = f_value.decode('utf-8')
 
     if f_value == 'UNKNOWN':
         return None

--- a/stallion/tests/test_metadata.py
+++ b/stallion/tests/test_metadata.py
@@ -37,5 +37,5 @@ class Test_metadata(unittest.TestCase):
         }, ret)
 
 if __name__ == '__main__':
-    print "Stallion v.%s" % __version__
+    print("Stallion v.%s" % __version__)
     unittest.main()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py25, py26, py27, pypy
+envlist = py25, py26, py27, py32, pypy
 
 [testenv]
 commands = nosetests stallion


### PR DESCRIPTION
These changes let the tests pass for Python 3:

```
__________________________________ [tox summary] ___________________________________
[TOX] py25: commands succeeded
[TOX] py26: commands succeeded
[TOX] py27: commands succeeded
[TOX] py32: commands succeeded
[TOX] pypy: commands succeeded
[TOX] congratulations :)
```

Stallion itself won't work with Python 3, because Flask doesn't yet, but it doesn't hurt to be ready for when it does...
