### PR TITLE
Add a sample launchd plist for managing Stallion on Mac OS X

### DIFF
--- a/stallion/write_plist.py
+++ b/stallion/write_plist.py
@@ -1,0 +1,24 @@
+import sys
+
+plist_sample_text="""
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>Stallone</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{python}</string>
+        <string>-m</string>
+        <string>stallion.main</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+</dict>
+</plist>
+""".strip()
+
+sys.stdout.write(plist_sample_text.format(python=sys.executable))


### PR DESCRIPTION
Adds a sample plist file and a really simple python program for substituting in the python interpreter.

Example usage:

```
~/dev/git-repos/stallion$ python -m stallion.write_plist > ~/Library/LaunchAgents/pyevolve.stallion.plist
~/dev/git-repos/stallion$ launchctl load -w ~/Library/LaunchAgents/pyevolve.stallion.plist
~/dev/git-repos/stallion$ pgrep -fl python
36744 /Users/marc/dev/git-repos/stallion/stallion.venv/bin/python -m stallion.main
```
