### PR TITLE
add Upstart service recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,36 @@ Upgrading using easy_install:
 
     $ easy_install -U stallion
 
+### Install as a service
+
+On Linux systems having [Upstart](http://upstart.ubuntu.com/) you can set up Stallion as a service easily as follow.
+
+- copy `contrib/upstart/stallion.conf` to `/etc/init/`
+- make a symbolic link for it in `/etc/init.d/`:
+
+    ```shell
+    $ ln -s /etc/init/stallion.conf /etc/init.d/stallion
+    ```
+
+#### Service management
+
+```shell
+$ sudo start stallion
+$ sudo stop stallion
+$ sudo status stallion
+```
+or
+```shell
+$ sudo service stallion start
+$ sudo service stallion stop
+$ sudo service stallion status
+```
+
+#### Service customization
+
+Stallion program output (stdout and stderr) is redirected into the log file at `/var/log/stallion.log`. You can override this by setting a new value to the `LOG` environment variable in file `/etc/default/stallion`.
+
+
 ## Using Stallion
 
 You only need to call the script (the -w option will automatically open your browser):

--- a/contrib/upstart/stallion.conf
+++ b/contrib/upstart/stallion.conf
@@ -1,0 +1,18 @@
+description "Stallion service"
+
+start on runlevel [2345]
+stop on runlevel [!2345]
+
+env LOG=/var/log/stallion.log
+env DEFAULTFILE=/etc/default/stallion
+
+pre-start script
+    # load defaults if default file exists
+    if [ -f "$DEFAULTFILE" ]; then
+        . "$DEFAULTFILE"
+    fi
+end script
+
+script
+    exec stallion >> $LOG 2>&1
+end script


### PR DESCRIPTION
I guess this could be work out a bit more to add the file `/etc/default/stallion` which could have variables for the HOST and PORT to bind.

Let me know what your plans are with this.
