### PR TITLE
better upstart script with config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ On Linux systems having [Upstart](http://upstart.ubuntu.com/) you can set up Sta
     ```shell
     $ ln -s /etc/init/stallion.conf /etc/init.d/stallion
     ```
+- copy `contrib/upstart/stallion` to `/etc/default/`
 
 #### Service management
 
@@ -94,7 +95,7 @@ $ sudo service stallion status
 
 #### Service customization
 
-Stallion program output (stdout and stderr) is redirected into the log file at `/var/log/stallion.log`. You can override this by setting a new value to the `LOG` environment variable in file `/etc/default/stallion`.
+You can customize the host and port the stallion service will be listening on by editing the file `/etc/default/stallion`.
 
 
 ## Using Stallion

--- a/contrib/upstart/stallion
+++ b/contrib/upstart/stallion
@@ -1,0 +1,4 @@
+# Configuration for the Stallion service
+
+HOST=0.0.0.0
+PORT=3000

--- a/contrib/upstart/stallion.conf
+++ b/contrib/upstart/stallion.conf
@@ -3,16 +3,16 @@ description "Stallion service"
 start on runlevel [2345]
 stop on runlevel [!2345]
 
-env LOG=/var/log/stallion.log
-env DEFAULTFILE=/etc/default/stallion
-
-pre-start script
-    # load defaults if default file exists
-    if [ -f "$DEFAULTFILE" ]; then
-        . "$DEFAULTFILE"
-    fi
-end script
-
 script
-    exec stallion >> $LOG 2>&1
+	exec >>/var/log/stallion.log 2>&1
+
+	# load defaults if default file exists
+	test -f "/etc/default/stallion" && . /etc/default/stallion
+
+	# makes sure HOST and PORT are set
+	test "$HOST" != "" || HOST=127.0.0.1
+	test "$PORT" != "" || PORT=5000
+
+	echo starting Stallion on $HOST:$PORT
+	exec stallion --host=$HOST --port=$PORT
 end script


### PR DESCRIPTION
This update brings an example config file.
It will make it easier for users to figure out out all this work.

Also thoroughly tested the script to make sure :
- it works without the config file
- it works with the config file
- config file values are taken into account
