### PR TITLE
Fixed a small error that prevented Stallion from starting in newer versions of Python 3

### DIFF
--- a/stallion/main.py
+++ b/stallion/main.py
@@ -10,6 +10,11 @@
 """
 from optparse import OptionParser
 
+try:
+    reload
+except NameError:
+    from imp import reload
+
 import sys
 import platform
 import logging


### PR DESCRIPTION
The error occurs because the "reload" function was moved to the imp module.